### PR TITLE
Update edit links to GitHub issues

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,13 +41,17 @@ const config = {
           path: 'docs',
           routeBasePath: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/Pantagrueliste/CavrianaCorr_FrontEnd/tree/main/',
+          editUrl: ({docPath}) =>
+            `https://github.com/Pantagrueliste/CavrianaCorr_FrontEnd/issues/new?title=${encodeURIComponent(
+              docPath,
+            )}&labels=error`,
         },
         blog: {
           showReadingTime: true,
-          editUrl:
-            'https://github.com/Pantagrueliste/CavrianaCorr_FrontEnd/tree/main/',
+          editUrl: ({blogPath}) =>
+            `https://github.com/Pantagrueliste/CavrianaCorr_FrontEnd/issues/new?title=${encodeURIComponent(
+              blogPath,
+            )}&labels=error`,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import IconEdit from '@theme/Icon/Edit';
+
+export default function EditThisPage({editUrl}) {
+  return (
+    <Link to={editUrl} className={ThemeClassNames.common.editThisPage}>
+      <IconEdit />
+      Signal an error
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- replace Docusaurus edit links with issue links
- add custom `EditThisPage` component with new label

## Testing
- `npm run build`
